### PR TITLE
MNT: Drop SSL3 protocol

### DIFF
--- a/appveyor/install_opengl.ps1
+++ b/appveyor/install_opengl.ps1
@@ -12,7 +12,7 @@ $MESA_GL_URL = "https://github.com/vispy/demo-data/raw/master/mesa/"
 #     http://sourceforge.net/projects/msys2/files/REPOS/MINGW/x86_64/mingw-w64-x86_64-mesa-10.2.4-1-any.pkg.tar.xz/download
 
 function DownloadMesaOpenGL ($architecture) {
-    [Net.ServicePointManager]::SecurityProtocol = 'Ssl3, Tls, Tls11, Tls12'
+    [Net.ServicePointManager]::SecurityProtocol = 'Tls, Tls11, Tls12'
     $webclient = New-Object System.Net.WebClient
     # Download and retry up to 3 times in case of network transient errors.
     $url = $MESA_GL_URL + "opengl32_mingw_" + $architecture + ".dll"


### PR DESCRIPTION
This PR drops SSL3 protocol which is not supported on the `windows-latest` configuration of GitHub Actions:

```
ParentContainsErrorRecordException: D:\a\pyvistaqt\pyvistaqt\gl-ci-helpers\appveyor\install_opengl.ps1:15
Line |
  15 |      [Net.ServicePointManager]::SecurityProtocol = 'Ssl3, Tls, Tls11,  …
     |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception setting "SecurityProtocol": "The requested security protocol is not supported."
```

Related to https://github.com/pyvista/pyvistaqt/pull/81#issuecomment-776872695