### PR TITLE
MNT: (404) not found

### DIFF
--- a/appveyor/install_opengl.ps1
+++ b/appveyor/install_opengl.ps1
@@ -4,7 +4,7 @@
 
 # Adapted from VisPy
 
-$MESA_GL_URL = "https://github.com/vispy/demo-data/raw/master/mesa/"
+$MESA_GL_URL = "https://github.com/vispy/demo-data/raw/main/mesa/"
 
 # Mesa DLLs found linked from:
 #     http://qt-project.org/wiki/Cross-compiling-Mesa-for-Windows


### PR DESCRIPTION
Vispy changed their main branch name from `master` to `main`. The `appveyor/install_opengl.ps1` needs to be updated to reflect those changes.

This PR fixes the URL used. 

Here is the log on `pyvistaqt`:

```
Cloning into 'gl-ci-helpers'...

SUCCESS: The file (or folder): "C:\Windows\system32\opengl32.dll" now owned by the administrators group.
processed file: C:\Windows\system32\opengl32.dll
Successfully processed 1 files; Failed processing 0 files
Downloading https://github.com/vispy/demo-data/raw/master/mesa/opengl32_mingw_64.dll
ParentContainsErrorRecordException: D:\a\pyvistaqt\pyvistaqt\gl-ci-helpers\appveyor\install_opengl.ps1:42
Line |
  42 |          $webclient.DownloadFile($url, $filepath)
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Exception calling "DownloadFile" with "2" argument(s): "The remote server returned an error: (404) Not
     | Found."

Error: Process completed with exit code 1.
```

https://github.com/pyvista/pyvistaqt/runs/2464629277?check_suite_focus=true#step:4:16